### PR TITLE
fix: Initialise network interface if Ethernet is enabled, but Wi-Fi is not

### DIFF
--- a/components/at/src/at_init.c
+++ b/components/at/src/at_init.c
@@ -62,7 +62,7 @@ static void at_wifi_statistics_task(void *params)
 
 esp_err_t esp_at_netif_init(void)
 {
-#ifdef CONFIG_AT_WIFI_COMMAND_SUPPORT
+#if defined(CONFIG_AT_WIFI_COMMAND_SUPPORT) || defined(CONFIG_AT_ETHERNET_SUPPORT)
     return esp_netif_init();
 #else
     return ESP_OK;


### PR DESCRIPTION
LWIP is not initialised when Wi-Fi is not enabled, but Ethernet is. This commit checks if the Ethernet has been enabled with the define CONFIG_AT_ETHERNET_SUPPORT, and if so initialise the network interface.