### PR TITLE
feat(env): Detect Linux package manager (apt-get/dnf) when installing prerequisites

### DIFF
--- a/build.py
+++ b/build.py
@@ -7,6 +7,7 @@ import os
 import sys
 import subprocess
 import json
+import shutil
 
 # color output on windows
 if sys.platform == 'win32':
@@ -467,12 +468,24 @@ def install_compilation_env(target):
 
     print('\r\nAll done! You can now run:\r\n\r\n  {}build.py build\r\n'.format('python ' if sys.platform == 'win32' else './'))
 
+def detect_linux_package_manager():
+    for pkg_mgr in ('apt-get', 'dnf'):
+        if shutil.which(pkg_mgr):
+            return pkg_mgr
+    return None
+
 def install_prerequisites():
     # install ESP-IDF prerequisites
     ESP_LOGI('Ready to install ESP-IDF prerequisites..')
     cmd = ''
     if sys.platform == 'linux':
-        cmd = 'sudo apt-get install git wget flex bison gperf python3 python3-pip python3-venv python3-setuptools cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0'
+        pkg_mgr = detect_linux_package_manager()
+        if pkg_mgr == 'dnf':
+            cmd = 'sudo dnf install git wget flex bison gperf python3 python3-setuptools cmake ninja-build ccache dfu-util libusbx'
+        else:
+            if pkg_mgr is None:
+                ESP_LOGW('No supported package manager (apt-get, dnf) found, defaulting to apt-get..')
+            cmd = 'sudo apt-get install git wget flex bison gperf python3 python3-pip python3-venv python3-setuptools cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0'
     elif sys.platform == 'darwin':
         cmd = 'brew install cmake ninja dfu-util ccache python3'
     elif sys.platform == 'win32':


### PR DESCRIPTION
## Summary

Fixes #1010

`./build.py install` currently assumes a Debian-based system and unconditionally runs `sudo apt-get install ...` on Linux. On distributions without apt-get (e.g. Fedora), the install step fails:

```
sudo: apt-get: command not found
A fatal error occurred: install prerequisites failed!
```

## Changes

- Added a small `detect_linux_package_manager()` helper that uses `shutil.which()` to find the first available supported package manager (`apt-get`, `dnf`).
- When `dnf` is detected, prerequisites are installed with the package list from the [ESP-IDF Get Started guide for Fedora](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html) (`libffi`/`openssl` dev headers are not needed there per IDF docs; `libusbx` replaces `libusb-1.0-0`).
- If no supported package manager is found, the script falls back to the previous `apt-get` behavior with a warning, so existing behavior on unknown systems is unchanged (the existing error message still prints the exact command to run manually).

## Testing

- Verified `detect_linux_package_manager()` returns `apt-get`/`dnf`/`None` correctly depending on which binaries are present.
- The dnf package set was validated on Fedora by the reporter of #1010 (successful full build attached in the issue).
- No behavior change on macOS, Windows, or Debian-based Linux.

Credit to @ChaiJahan for reporting the issue and proposing the initial approach.